### PR TITLE
Scala 2.12 examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,15 @@ libraryDependencies := {
     // if scala 2.12+ is used, use scala-swing 2.x
     case Some((2, scalaMajor)) if scalaMajor >= 12 =>
       libraryDependencies.value ++ Seq(
-        "org.scala-lang.modules" %% "scala-xml" % "1.0.3",
-        "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.3",
+        "org.scala-lang.modules" %% "scala-xml" % "1.0.6",
+        "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4",
         "org.scala-lang.modules" %% "scala-swing" % "2.0.0-M2")
     // if scala 2.11+ is used, add dependency on scala-xml module
     case Some((2, scalaMajor)) if scalaMajor >= 11 =>
       libraryDependencies.value ++ Seq(
-        "org.scala-lang.modules" %% "scala-xml" % "1.0.3",
-        "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.3",
-        "org.scala-lang.modules" %% "scala-swing" % "1.0.1")
+        "org.scala-lang.modules" %% "scala-xml" % "1.0.6",
+        "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4",
+        "org.scala-lang.modules" %% "scala-swing" % "1.0.2")
     case _ =>
       // or just libraryDependencies.value if you don't depend on scala-swing
       libraryDependencies.value :+ "org.scala-lang" % "scala-swing" % scalaVersion.value
@@ -44,17 +44,17 @@ This to depend on scala-xml module with assumption that you have `scalaBinaryVer
 <dependency>
   <groupId>org.scala-lang.modules</groupId>
   <artifactId>scala-xml_${scalaBinaryVersion}</artifactId>
-  <version>1.0.3</version>
+  <version>1.0.6</version>
 </dependency>
 <dependency>
   <groupId>org.scala-lang.modules</groupId>
   <artifactId>scala-parser-combinators_${scalaBinaryVersion}</artifactId>
-  <version>1.0.3</version>
+  <version>1.0.4</version>
 </dependency>
 <dependency>
   <groupId>org.scala-lang.modules</groupId>
   <artifactId>scala-swing_${scalaBinaryVersion}</artifactId>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ This sample demonstrates how to conditionally depend on all modules. If use only
 // taken from: http://github.com/scala/scala-module-dependency-sample
 libraryDependencies := {
   CrossVersion.partialVersion(scalaVersion.value) match {
+    // if scala 2.12+ is used, use scala-swing 2.x
+    case Some((2, scalaMajor)) if scalaMajor >= 12 =>
+      libraryDependencies.value ++ Seq(
+        "org.scala-lang.modules" %% "scala-xml" % "1.0.3",
+        "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.3",
+        "org.scala-lang.modules" %% "scala-swing" % "2.0.0-M2")
     // if scala 2.11+ is used, add dependency on scala-xml module
     case Some((2, scalaMajor)) if scalaMajor >= 11 =>
       libraryDependencies.value ++ Seq(
@@ -57,4 +63,4 @@ This to depend on scala-xml module with assumption that you have `scalaBinaryVer
 ### Scala cross-versioning with Maven
 
 The snippet provided above allows you to declare dependencies on modules shipped against Scala 2.11. If you would like to
-support building your project with both Scala 2.10 and 2.11 at the same time you'll need to use [Maven profiles](http://maven.apache.org/guides/introduction/introduction-to-profiles.html). Check the `pom.xml` file in the sample project for details how to set up Maven profiles for supporting different Scala versions.
+support building your project with both Scala 2.10, 2.11 and 2.12 at the same time you'll need to use [Maven profiles](http://maven.apache.org/guides/introduction/introduction-to-profiles.html). Check the `pom.xml` file in the sample project for details how to set up Maven profiles for supporting different Scala versions.

--- a/maven-sample/pom.xml
+++ b/maven-sample/pom.xml
@@ -8,10 +8,39 @@
     the right dependencies for modules specified for each version separately -->
   <profiles>
     <profile>
-      <id>scala-2.11</id>
+      <id>scala-2.12</id>
       <activation>
         <activeByDefault>true</activeByDefault>
       </activation>
+      <properties>
+        <scalaVersion>2.12.0-M4</scalaVersion>
+        <scalaBinaryVersion>2.12.0-M4</scalaBinaryVersion>
+      </properties>
+      <dependencies>
+          <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+            <version>${scalaVersion}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.scala-lang.modules</groupId>
+            <artifactId>scala-xml_${scalaBinaryVersion}</artifactId>
+            <version>1.0.5</version>
+          </dependency>
+          <dependency>
+            <groupId>org.scala-lang.modules</groupId>
+            <artifactId>scala-parser-combinators_${scalaBinaryVersion}</artifactId>
+            <version>1.0.4</version>
+          </dependency>
+          <dependency>
+            <groupId>org.scala-lang.modules</groupId>
+            <artifactId>scala-swing_${scalaBinaryVersion}</artifactId>
+            <version>2.0.0-M2</version>
+          </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>scala-2.11</id>
       <properties>
         <scalaVersion>2.11.8</scalaVersion>
         <scalaBinaryVersion>2.11</scalaBinaryVersion>

--- a/maven-sample/pom.xml
+++ b/maven-sample/pom.xml
@@ -25,7 +25,7 @@
           <dependency>
             <groupId>org.scala-lang.modules</groupId>
             <artifactId>scala-xml_${scalaBinaryVersion}</artifactId>
-            <version>1.0.5</version>
+            <version>1.0.6</version>
           </dependency>
           <dependency>
             <groupId>org.scala-lang.modules</groupId>
@@ -54,7 +54,7 @@
           <dependency>
             <groupId>org.scala-lang.modules</groupId>
             <artifactId>scala-xml_${scalaBinaryVersion}</artifactId>
-            <version>1.0.5</version>
+            <version>1.0.6</version>
           </dependency>
           <dependency>
             <groupId>org.scala-lang.modules</groupId>

--- a/maven-sample/pom.xml
+++ b/maven-sample/pom.xml
@@ -4,7 +4,7 @@
   <groupId>sample</groupId>
   <artifactId>scala-module-dependency-sample</artifactId>
   <version>1.0-SNAPSHOT</version>
-  <!-- Maven profiles allow you to support both Scala 2.10 and Scala 2.11 with
+  <!-- Maven profiles allow you to support both Scala 2.10, 2.11 and Scala 2.12 with
     the right dependencies for modules specified for each version separately -->
   <profiles>
     <profile>
@@ -13,8 +13,8 @@
         <activeByDefault>true</activeByDefault>
       </activation>
       <properties>
-        <scalaVersion>2.12.0-M4</scalaVersion>
-        <scalaBinaryVersion>2.12.0-M4</scalaBinaryVersion>
+        <scalaVersion>2.12.0-RC1</scalaVersion>
+        <scalaBinaryVersion>2.12.0-RC1</scalaBinaryVersion>
       </properties>
       <dependencies>
           <dependency>

--- a/sbt-sample/build.sbt
+++ b/sbt-sample/build.sbt
@@ -4,9 +4,9 @@ organization := "sample"
 
 version := "1.0"
 
-crossScalaVersions := Seq("2.12.0-M4", "2.11.8", "2.10.5")
+crossScalaVersions := Seq("2.12.0-RC1", "2.11.8", "2.10.6")
 
-scalaVersion := "2.12.0-M4"
+scalaVersion := "2.12.0-RC1"
 
 // add scala-xml dependency when needed (for Scala 2.11 and newer) in a robust way
 // this mechanism supports cross-version publishing

--- a/sbt-sample/build.sbt
+++ b/sbt-sample/build.sbt
@@ -4,9 +4,9 @@ organization := "sample"
 
 version := "1.0"
 
-crossScalaVersions := Seq("2.11.8", "2.10.5")
+crossScalaVersions := Seq("2.12.0-M4", "2.11.8", "2.10.5")
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.12.0-M4"
 
 // add scala-xml dependency when needed (for Scala 2.11 and newer) in a robust way
 // this mechanism supports cross-version publishing
@@ -17,7 +17,7 @@ libraryDependencies := {
       libraryDependencies.value ++ Seq(
         "org.scala-lang.modules" %% "scala-xml" % "1.0.5",
         "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4",
-        "org.scala-lang.modules" %% "scala-swing" % "1.0.2")
+        "org.scala-lang.modules" %% "scala-swing" % "2.0.0-M2")
     case _ =>
       // or just libraryDependencies.value if you don't depend on scala-swing
       libraryDependencies.value :+ "org.scala-lang" % "scala-swing" % scalaVersion.value

--- a/sbt-sample/build.sbt
+++ b/sbt-sample/build.sbt
@@ -15,7 +15,7 @@ libraryDependencies := {
     // if scala 2.11+ is used, add dependency on scala-xml module
     case Some((2, scalaMajor)) if scalaMajor >= 11 =>
       libraryDependencies.value ++ Seq(
-        "org.scala-lang.modules" %% "scala-xml" % "1.0.5",
+        "org.scala-lang.modules" %% "scala-xml" % "1.0.6",
         "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4",
         "org.scala-lang.modules" %% "scala-swing" % "2.0.0-M2")
     case _ =>


### PR DESCRIPTION
I noticed there is no documentation for using the scala-lang modules with Scala version 2.12.  I've updated the README as well as the SBT and Maven example projects.  The only complication is that scala-swing needs to be incremented to a 2.0-series of releases to work with Scala 2.12.