### PR TITLE
Unable to run scala-xml 1.0.6 on 2.11.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ scala: dummy # using crossScalaVersions over TRAVIS_SCALA_VERSION
 script:
  - cd sbt-sample
  - sbt +update
+ - sbt ++2.11.8 "runMain ExponentialTransformer"
+ - sbt ++2.12.0 "runMain ExponentialTransformer"
+ - sbt ++2.12.1 "runMain ExponentialTransformer"
  - cd -
  - cd maven-sample
  - mvn compile

--- a/sbt-sample/ExponentialTransformer.scala
+++ b/sbt-sample/ExponentialTransformer.scala
@@ -1,0 +1,21 @@
+import scala.xml._
+
+object ExponentialTransformer extends App {
+
+    var i = 0
+    def translate(text: String): String = {
+        i += 1
+        return "!%s!".format(text)
+    }
+     
+    val xmlNode = <a><b><c><h1>Hello Example</h1></c></b></a>
+     
+    new transform.RuleTransformer(new transform.RewriteRule {
+        override def transform(n: Node): Seq[Node] = n match {
+            case t: Text if !t.text.trim.isEmpty => Text(translate(t.text.trim))
+            case _ => n
+        }
+    }).transform(xmlNode)
+    
+    println(s"scala.xml.transform.RuleTransformer called $i time(s)")
+}


### PR DESCRIPTION
After adding the library dependency for scala-xml 1.0.6 to an SBT project, there's evidence the new version is not being used.

In scala/scala-xml#125, a user reported the new version of scala-xml didn't include an improvement it was supposed to have.

This isn't a pull request.  It provides code for a test driver, `ExponentialTransformer`, that can confirm if `scala.xml.transform.RuleTransformer` makes just one call or is the old version that makes 32 calls.

    $ sbt ++2.11.8 "runMain ExponentialTransformer" 
    [info] Running ExponentialTransformer 
    scala.xml.transform.RuleTransformer called 32 time(s)
    [success] Total time: 1 s, completed
    $ sbt ++2.12.0 "runMain ExponentialTransformer" 
    [info] Running ExponentialTransformer 
    scala.xml.transform.RuleTransformer called 32 time(s)
    [success] Total time: 14 s, completed
    $ sbt ++2.12.1 "runMain ExponentialTransformer"
    [info] Running ExponentialTransformer 
    scala.xml.transform.RuleTransformer called 1 time(s)
    [success] Total time: 14 s, completed

Unsurprisingly, the correct version of scala-xml 1.0.6 is called when run by Java directly  with what you think the classpath should be:

    $ java -cp target/scala-2.11/classes:$HOME/.ivy2/cache/org.scala-lang/scala-compiler/jars/scala-compiler-2.11.8.jar:$HOME/.ivy2/cache/org.scala-lang/scala-library/jars/scala-library-2.11.8.jar:$HOME/.ivy2/cache/org.scala-lang.modules/scala-xml_2.11/bundles/scala-xml_2.11-1.0.6.jar ExponentialTransformer
    scala.xml.transform.RuleTransformer called 1 time(s)
    
    $ java -cp target/scala-2.12/classes:$HOME/.ivy2/cache/org.scala-lang/scala-compiler/jars/scala-compiler-2.12.0.jar:$HOME/.ivy2/cache/org.scala-lang/scala-library/jars/scala-library-2.12.0.jar:$HOME/.ivy2/cache/org.scala-lang.modules/scala-xml_2.12/bundles/scala-xml_2.12-1.0.6.jar ExponentialTransformer
    scala.xml.transform.RuleTransformer called 1 time(s)

This is what SBT reports the classpath to be:

       > show fullClasspath
    [info] * Attributed(scala-module-dependency-sample/sbt-sample/target/scala-2.11/classes)
    [info] * Attributed(~/.ivy2/cache/org.scala-lang/scala-library/jars/scala-library-2.11.8.jar)
    [info] * Attributed(~/.ivy2/cache/org.scala-lang.modules/scala-xml_2.11/bundles/scala-xml_2.11-1.0.6.jar)
    [...]
