### PR TITLE
Update versions in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ libraryDependencies := {
     // if Scala 2.12+ is used, use scala-swing 2.x
     case Some((2, scalaMajor)) if scalaMajor >= 12 =>
       libraryDependencies.value ++ Seq(
-        "org.scala-lang.modules" %% "scala-xml" % "1.0.6",
-        "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4",
-        "org.scala-lang.modules" %% "scala-swing" % "2.0.0-M2")
+        "org.scala-lang.modules" %% "scala-xml" % "1.1.1",
+        "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.1",
+        "org.scala-lang.modules" %% "scala-swing" % "2.0.3")
     case Some((2, scalaMajor)) if scalaMajor >= 11 =>
       libraryDependencies.value ++ Seq(
-        "org.scala-lang.modules" %% "scala-xml" % "1.0.6",
-        "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4",
+        "org.scala-lang.modules" %% "scala-xml" % "1.1.1",
+        "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.1",
         "org.scala-lang.modules" %% "scala-swing" % "1.0.2")
     case _ =>
       // or just libraryDependencies.value if you don't depend on scala-swing
@@ -50,17 +50,17 @@ The following `pom.xml` snippet assumes you define a `scala.compat.version` prop
 <dependency>
   <groupId>org.scala-lang.modules</groupId>
   <artifactId>scala-xml_${scala.compat.version}</artifactId>
-  <version>1.0.6</version>
+  <version>1.1.1</version>
 </dependency>
 <dependency>
   <groupId>org.scala-lang.modules</groupId>
   <artifactId>scala-parser-combinators_${scala.compat.version}</artifactId>
-  <version>1.0.4</version>
+  <version>1.1.1</version>
 </dependency>
 <dependency>
   <groupId>org.scala-lang.modules</groupId>
   <artifactId>scala-swing_${scala.compat.version}</artifactId>
-  <version>1.0.2</version>
+  <version>2.0.3</version>
 </dependency>
 ```
 

--- a/maven-sample/pom.xml
+++ b/maven-sample/pom.xml
@@ -16,7 +16,7 @@
         <activeByDefault>true</activeByDefault>
       </activation>
       <properties>
-        <scala.version>2.12.0</scala.version>
+        <scala.version>2.12.7</scala.version>
         <scala.compat.version>2.12</scala.compat.version>
       </properties>
       <dependencies>
@@ -28,24 +28,24 @@
           <dependency>
             <groupId>org.scala-lang.modules</groupId>
             <artifactId>scala-xml_${scala.compat.version}</artifactId>
-            <version>1.0.6</version>
+            <version>1.1.1</version>
           </dependency>
           <dependency>
             <groupId>org.scala-lang.modules</groupId>
             <artifactId>scala-parser-combinators_${scala.compat.version}</artifactId>
-            <version>1.0.4</version>
+            <version>1.1.1</version>
           </dependency>
           <dependency>
             <groupId>org.scala-lang.modules</groupId>
             <artifactId>scala-swing_${scala.compat.version}</artifactId>
-            <version>2.0.0-M2</version>
+            <version>2.0.3</version>
           </dependency>
       </dependencies>
     </profile>
     <profile>
       <id>scala-2.11</id>
       <properties>
-        <scala.version>2.11.8</scala.version>
+        <scala.version>2.11.12</scala.version>
         <scala.compat.version>2.11</scala.compat.version>
       </properties>
       <dependencies>
@@ -57,12 +57,12 @@
           <dependency>
             <groupId>org.scala-lang.modules</groupId>
             <artifactId>scala-xml_${scala.compat.version}</artifactId>
-            <version>1.0.6</version>
+            <version>1.1.1</version>
           </dependency>
           <dependency>
             <groupId>org.scala-lang.modules</groupId>
             <artifactId>scala-parser-combinators_${scala.compat.version}</artifactId>
-            <version>1.0.4</version>
+            <version>1.1.1</version>
           </dependency>
           <dependency>
             <groupId>org.scala-lang.modules</groupId>
@@ -74,7 +74,7 @@
     <profile>
       <id>scala-2.10</id>
       <properties>
-        <scala.version>2.10.6</scala.version>
+        <scala.version>2.10.7</scala.version>
         <scala.compat.version>2.10</scala.compat.version>
       </properties>
       <dependencies>

--- a/sbt-sample/build.sbt
+++ b/sbt-sample/build.sbt
@@ -4,9 +4,9 @@ organization := "sample"
 
 version := "1.0"
 
-crossScalaVersions := Seq("2.12.0", "2.11.8", "2.10.6")
+crossScalaVersions := Seq("2.12.7", "2.11.12", "2.10.7")
 
-scalaVersion := "2.12.0"
+scalaVersion := "2.12.7"
 
 // add dependencies on standard Scala modules, in a way
 // supporting cross-version publishing
@@ -16,13 +16,13 @@ libraryDependencies := {
     // if Scala 2.12+ is used, use scala-swing 2.x
     case Some((2, scalaMajor)) if scalaMajor >= 12 =>
       libraryDependencies.value ++ Seq(
-        "org.scala-lang.modules" %% "scala-xml" % "1.0.6",
-        "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4",
-        "org.scala-lang.modules" %% "scala-swing" % "2.0.0-M2")
+        "org.scala-lang.modules" %% "scala-xml" % "1.1.1",
+        "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.1",
+        "org.scala-lang.modules" %% "scala-swing" % "2.0.3")
     case Some((2, scalaMajor)) if scalaMajor >= 11 =>
       libraryDependencies.value ++ Seq(
-        "org.scala-lang.modules" %% "scala-xml" % "1.0.6",
-        "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4",
+        "org.scala-lang.modules" %% "scala-xml" % "1.1.1",
+        "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.1",
         "org.scala-lang.modules" %% "scala-swing" % "1.0.2")
     case _ =>
       // or just libraryDependencies.value if you don't depend on scala-swing

--- a/sbt-sample/project/build.properties
+++ b/sbt-sample/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.17


### PR DESCRIPTION
Fixes both Maven, sbt and the README.

Will conflict with #16, so please merge that first, if possible..

- sbt 0.13.17
- Scala 2.10.7
- Scala 2.11.12
- Scala 2.12.7
- scala-parser-combinators 1.1.1
- scala-swing 2.0.3
- scala-xml 1.1.1

\cc @gourlaysama, @benhutchison, @SethTisue.